### PR TITLE
SystemD watchdog support

### DIFF
--- a/spec/systemd_spec.cr
+++ b/spec/systemd_spec.cr
@@ -52,4 +52,20 @@ describe SystemD do
     c.close
     s.close
   end
+
+  it "can send watchdog keepalives" do
+    ENV["WATCHDOG_USEC"] = "100"
+    ENV["NOTIFY_SOCKET"] = path = File.tempname
+    begin
+      sock = Socket.unix(Socket::Type::DGRAM)
+      sock.bind Socket::UNIXAddress.new(path)
+
+      SystemD.start_watchdog
+
+      message, _ = sock.receive
+      message.should eq "WATCHDOG=1\n"
+    ensure
+      File.delete path
+    end
+  end
 end

--- a/src/systemd.cr
+++ b/src/systemd.cr
@@ -26,7 +26,7 @@ module SystemD
   # If systemd doesn't get a ping every `WATCHDOG_USEC` it will kill the process.
   # This method can always be called, if watchdog isn't enabled in systemd or
   # the process is not running under systemd it will do nothing.
-  def self.start_watchdog(&callback : -> _)
+  def self.watchdog(&callback : -> _)
     sock_path = ENV["NOTIFY_SOCKET"]? || return
     interval = self.watchdog_interval? || return
     interval = interval / 2
@@ -40,7 +40,7 @@ module SystemD
     end
   end
 
-  def self.start_watchdog
+  def self.watchdog
     self.start_watchdog { true }
   end
 

--- a/src/systemd.cr
+++ b/src/systemd.cr
@@ -22,7 +22,7 @@ module SystemD
   end
 
   # Report to systemd in a separate fiber
-  # If the *callback* returns false the will be executed every time, return true if your check is ok.
+  # The *callback* should return a trueish value or else the keepalive won't be sent
   # If systemd doesn't get a ping every `WATCHDOG_USEC` it will kill the process.
   # This method can always be called, if watchdog isn't enabled in systemd or
   # the process is not running under systemd it will do nothing.


### PR DESCRIPTION
`Systemd.start_watchdog` starts a fiber that will keep-alive ping systemd with watchdog notifications repeatedly dependent on the environment variable WATCHDOG_USEC interval setting.

Reference:
https://www.man7.org/linux/man-pages/man5/systemd.service.5.html
