### PR TITLE
Support the new Type=notify-reload

### DIFF
--- a/src/systemd.cr
+++ b/src/systemd.cr
@@ -14,7 +14,8 @@ module SystemD
   end
 
   def self.notify_reloading
-    self.notify("RELOADING=1\n")
+    usec = Time.monotonic.total_microseconds.to_u64
+    self.notify("RELOADING=1\nMONOTONIC_USEC=#{usec}\n")
   end
 
   def self.notify_status(status : String)


### PR DESCRIPTION
When the SystemD service Type is notify-reload the application has to send the `MONOTONIC_USEC` variable too, for systemd to understand the ordering of async reload signals.

Reference: https://www.man7.org/linux/man-pages/man5/systemd.service.5.html